### PR TITLE
Add tier-gated Tab Marketplace with animated UI

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -52,6 +52,9 @@ const Header = () => {
             <Link to="/dashboard" className="header__button">{t('header.dashboard')}</Link>
             <Link to="/wallet" className="header__button">{t('header.wallet')}</Link>
             <Link to="/profile" className="header__button">{t('header.profile')}</Link>
+            {user.account_tier >= 2 && (
+              <Link to="/tabs-market" className="header__button header__button--glow">{t('header.tab_market')}</Link>
+            )}
             {user.isAdmin && (<Link to="/admin" className="header__button header__button--admin">{t('header.admin')}</Link>)}
             <button onClick={handleLogout} className="header__button header__button--primary">{t('header.logout')}</button>
           </>
@@ -80,6 +83,7 @@ const Header = () => {
                           <Link to="/dashboard" className="mobile-menu__link" onClick={closeMobileMenu}>{t('header.dashboard')}</Link>
                           <Link to="/wallet" className="mobile-menu__link" onClick={closeMobileMenu}>{t('header.wallet')}</Link>
                           <Link to="/profile" className="mobile-menu__link" onClick={closeMobileMenu}>{t('header.profile')}</Link>
+                          {user.account_tier >= 2 && <Link to="/tabs-market" className="mobile-menu__link" onClick={closeMobileMenu}>{t('header.tab_market')}</Link>}
                           {user.isAdmin && <Link to="/admin" className="mobile-menu__link" onClick={closeMobileMenu}>{t('header.admin')}</Link>}
                           <button onClick={() => { handleLogout(); closeMobileMenu(); }} className="mobile-menu__button">{t('header.logout')}</button>
                       </>

--- a/src/components/TierRoute.jsx
+++ b/src/components/TierRoute.jsx
@@ -1,0 +1,27 @@
+// src/components/TierRoute.jsx
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+/**
+ * Restricts access to users who have at least the specified account tier.
+ * Redirects to the dashboard if the requirement is not met.
+ */
+const TierRoute = ({ minTier = 2, children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) return null;
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const userTier = user.account_tier || 1;
+  if (userTier < minTier) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+};
+
+export default TierRoute;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -10,6 +10,7 @@
     "logout": "Abmelden",
     "signin": "Anmelden",
     "register": "Registrieren",
+    "tab_market": "Tab-Marktplatz",
     "alt_logo": "Hyper-Strategies Logo"
   },
   "footer": {
@@ -320,5 +321,12 @@
     "syndicate_title": "Syndikat-Empfehlungen",
     "syndicate_description": "Schließen Sie sich mit einer Community zusammen, um gemeinsame Empfehlungsprämien zu verdienen. Demnächst verfügbar.",
     "learn_more_button": "Mehr erfahren"
+  }
+  ,"tabs_market": {
+    "title": "Tab-Marktplatz",
+    "buy": "Kaufen",
+    "sell": "Verkaufen",
+    "error_loading": "Tabs konnten nicht geladen werden.",
+    "empty": "Keine Tabs verfügbar."
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,7 @@
     "logout": "Logout",
     "signin": "Sign In",
     "register": "Register",
+    "tab_market": "Tab Market",
     "alt_logo": "Hyper-Strategies Logo"
   },
   "footer": {
@@ -320,5 +321,12 @@
     "syndicate_title": "Syndicate Referrals",
     "syndicate_description": "Join forces with a community to earn shared referral rewards. Coming soon.",
     "learn_more_button": "Learn More"
+  }
+  ,"tabs_market": {
+    "title": "Tab Marketplace",
+    "buy": "Buy",
+    "sell": "Sell",
+    "error_loading": "Unable to load tabs.",
+    "empty": "No tabs available."
   }
 }

--- a/src/pages/Router.jsx
+++ b/src/pages/Router.jsx
@@ -18,6 +18,7 @@ import Wallet from './Wallet';
 import OAuthSuccess from './OAuthSuccess';
 import FAQ from './FAQ';
 import FeeStructure from './FeeStructure';
+import TabsMarketplace from './TabsMarketplace';
 
 import AdminDashboard from './admin/AdminDashboard';
 import FinancialsPage from './admin/FinancialsPage';
@@ -30,6 +31,7 @@ import VaultManagementPage from './admin/VaultManagementPage';
 import ProtectedRoute from '../components/ProtectedRoute';
 import GuestRoute from '../components/GuestRoute';
 import AdminRoute from '../components/AdminRoute';
+import TierRoute from '../components/TierRoute';
 
 const Router = () => {
   return (
@@ -53,6 +55,7 @@ const Router = () => {
       <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
       <Route path="/wallet" element={<ProtectedRoute><Wallet /></ProtectedRoute>} />
       <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
+      <Route path="/tabs-market" element={<TierRoute><TabsMarketplace /></TierRoute>} />
           
       {/* --- ADMIN-ONLY Protected Routes --- */}
       {/* --- ANNOTATION --- I've standardized the main admin route to just /admin for simplicity */}

--- a/src/pages/TabsMarketplace.jsx
+++ b/src/pages/TabsMarketplace.jsx
@@ -1,0 +1,74 @@
+// src/pages/TabsMarketplace.jsx
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import api from '../api/api';
+import Layout from '../components/Layout';
+
+const TabsMarketplace = () => {
+  const { t } = useTranslation();
+  const [tabs, setTabs] = useState([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchTabs = async () => {
+      try {
+        const res = await api.get('/tabs/marketplace');
+        setTabs(res.data);
+      } catch (err) {
+        setError(t('tabs_market.error_loading'));
+      }
+    };
+    fetchTabs();
+  }, [t]);
+
+  const handleBuy = async (id) => {
+    try {
+      await api.post(`/tabs/${id}/buy`);
+      // refresh listings
+      setTabs(prev => prev.filter(tab => tab.id !== id));
+    } catch (err) {
+      console.error('Buy failed', err);
+    }
+  };
+
+  const handleSell = async (id) => {
+    try {
+      await api.post(`/tabs/${id}/sell`);
+    } catch (err) {
+      console.error('Sell failed', err);
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="tabs-market">
+        <h2 className="market-title gradient-text">{t('tabs_market.title')}</h2>
+        {error && <p className="error-message">{error}</p>}
+        <div className="market-grid">
+          {tabs.map(tab => (
+            <motion.div
+              key={tab.id}
+              className="tab-card"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              whileHover={{ scale: 1.03, rotateY: 5 }}
+            >
+              <h3>{tab.name}</h3>
+              <p className="price">${tab.price}</p>
+              <div className="actions">
+                <button className="btn-primary" onClick={() => handleBuy(tab.id)}>{t('tabs_market.buy')}</button>
+                <button className="btn-secondary" onClick={() => handleSell(tab.id)}>{t('tabs_market.sell')}</button>
+              </div>
+            </motion.div>
+          ))}
+          {tabs.length === 0 && !error && (
+            <p className="empty-message">{t('tabs_market.empty')}</p>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default TabsMarketplace;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1967,6 +1967,27 @@ textarea.input-field { resize: vertical; }
   background-color: #dc2626; /* A darker red for hover */
 }
 
+.header__button--glow {
+  position: relative;
+  overflow: hidden;
+}
+.header__button--glow::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  background: linear-gradient(45deg, #00f5ff, #ff00ff, #00f5ff);
+  z-index: -1;
+  filter: blur(6px);
+  opacity: 0.6;
+  transition: opacity 0.3s ease-in-out;
+}
+.header__button--glow:hover::after {
+  opacity: 1;
+}
+
 
 .admin-container {
   max-width: 1200px;
@@ -3314,4 +3335,52 @@ input:checked + .slider:before {
 
 .path-selector-section .card__footer {
   text-align: center; /* Center the button within the card */
+}
+
+/* --- Tabs Marketplace --- */
+.tabs-market {
+  padding: 40px 20px;
+}
+
+.market-title {
+  text-align: center;
+  font-size: 32px;
+  margin-bottom: 32px;
+}
+
+.gradient-text {
+  background: linear-gradient(90deg, #00f5ff, #ff00ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.market-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.tab-card {
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid var(--color-primary);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 0 20px rgba(0, 245, 255, 0.1);
+  backdrop-filter: blur(4px);
+}
+
+.tab-card .price {
+  font-size: 20px;
+  margin: 8px 0 16px;
+  color: var(--color-primary);
+}
+
+.tab-card .actions {
+  display: flex;
+  gap: 12px;
+}
+
+.empty-message {
+  text-align: center;
+  grid-column: 1 / -1;
 }


### PR DESCRIPTION
## Summary
- create `TierRoute` to restrict pages by minimum account tier
- add Tab Marketplace page with buy/sell actions and framer-motion cards
- expose marketplace link in navigation for Tier 2+ users with glowing accent
- include translations and styling for the new shop

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6897b631f1888329b1f2e5a6a195bbcc