### PR TITLE
Add user_tabs backend model and CRUD utilities

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,14 @@
+import { Sequelize } from 'sequelize';
+
+// Initialize SQLite database using Sequelize
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: 'database.sqlite',
+  logging: false,
+});
+
+export default sequelize;
+export const initDb = async () => {
+  await sequelize.authenticate();
+  await sequelize.sync();
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,9 @@
+import sequelize, { initDb } from '../db.js';
+import UserTab from './userTab.js';
+
+// Initialize database and models
+export const initializeModels = async () => {
+  await initDb();
+};
+
+export { sequelize, UserTab };

--- a/backend/models/userTab.js
+++ b/backend/models/userTab.js
@@ -1,0 +1,30 @@
+import { DataTypes } from 'sequelize';
+import sequelize from '../db.js';
+
+// user_tabs table definition
+const UserTab = sequelize.define('UserTab', {
+  user_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  tab_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  acquired_at: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW,
+  },
+}, {
+  tableName: 'user_tabs',
+  timestamps: false,
+  indexes: [
+    {
+      unique: true,
+      fields: ['user_id', 'tab_id'],
+    },
+  ],
+});
+
+export default UserTab;

--- a/backend/services/userTabService.js
+++ b/backend/services/userTabService.js
@@ -1,0 +1,23 @@
+import UserTab from '../models/userTab.js';
+
+export const createUserTab = async (user_id, tab_id, acquired_at = new Date()) => {
+  return await UserTab.create({ user_id, tab_id, acquired_at });
+};
+
+export const getUserTab = async (user_id, tab_id) => {
+  return await UserTab.findOne({ where: { user_id, tab_id } });
+};
+
+export const updateUserTab = async (user_id, tab_id, updates) => {
+  const record = await getUserTab(user_id, tab_id);
+  if (!record) return null;
+  return await record.update(updates);
+};
+
+export const deleteUserTab = async (user_id, tab_id) => {
+  return await UserTab.destroy({ where: { user_id, tab_id } });
+};
+
+export const listUserTabs = async (user_id) => {
+  return await UserTab.findAll({ where: { user_id } });
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "react-rotating-text": "^1.4.1",
     "react-router-dom": "^6.25.1",
     "react-scripts": "5.0.1",
+    "sequelize": "^6.37.1",
+    "sqlite3": "^5.1.7",
     "simplex-noise": "^4.0.3",
     "typescript": "^3.2.1"
   },


### PR DESCRIPTION
## Summary
- set up Sequelize/SQLite backend connection
- add `user_tabs` model with composite unique index
- provide CRUD service helpers for user tab records

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689a5ea161b08329bf93662064a41d84