### PR TITLE
seed: add tab catalog with placeholders

### DIFF
--- a/src/data/tabCatalog.js
+++ b/src/data/tabCatalog.js
@@ -1,0 +1,13 @@
+export const tabCatalog = [
+  { id: 1, name: 'Early Bird', effect: '0.05% Performance Fee reduction' },
+  { id: 2, name: 'ShdwMf Syndicate', effect: '0.05% Performance Fee reduction' },
+  { id: 3, name: 'Hip-Hop Syndicate', effect: '0.1% Performance Fee reduction' },
+  { id: 4, name: 'Hip-Hop Cabal', effect: '0.2% Performance Fee reduction' },
+  { id: 5, name: 'D.M.T', effect: 'Coming Soon' },
+  { id: 6, name: 'Frogs Jump Higher', effect: 'Coming Soon' },
+  { id: 7, name: 'Hypio', effect: 'Coming Soon' },
+  { id: 8, name: 'Placeholder Tab 1', effect: 'Coming Soon' },
+  { id: 9, name: 'Placeholder Tab 2', effect: 'Coming Soon' },
+];
+
+export default tabCatalog;


### PR DESCRIPTION
## Summary
- seed initial tab catalog with early fee-reduction tabs and placeholders for upcoming tabs

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6899151299988329a448d230cd500813