### PR TITLE
Add hero fade-in animation with scroll cue

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import useIsIOS from '../hooks/useIsIOS';
 import AddToHomeScreenPrompt from '../components/AddToHomeScreenPrompt';
 import Layout from '../components/Layout';
 import ChartImage from '../assets/chart-placeholder.png';
+import { motion } from 'framer-motion';
 
 const Home = () => {
   const { t, ready } = useTranslation();
@@ -58,7 +59,12 @@ const Home = () => {
     <>
       <Layout>
         <div className="hero-section-wrapper">
-          <section className="hero-section">
+          <motion.section
+            className="hero-section"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
             <div className="hero-content">
               <h1 className="hero-headline">
                 <RotatingText
@@ -87,7 +93,8 @@ const Home = () => {
             <div className="hero-image-container">
               <img src={ChartImage} alt="Trading Chart" className="hero-image" />
             </div>
-          </section>
+            <div className="scroll-cue">▼ Scroll</div>
+          </motion.section>
         </div>
         
         {/* --- REVERTED: Using the original path-selector-section and card mapping --- */}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1754,11 +1754,31 @@ textarea.input-field { resize: vertical; }
   max-width: 1200px;
   margin: 80px auto; /* Centers the section with top/bottom margin */
   padding: 0 24px;
+  position: relative;
 }
 
 .hero-content {
   /* This container for text doesn't need much styling now */
   text-align: left;
+}
+
+.scroll-cue {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  opacity: 0.7;
+  animation: scrollCueBounce 2s infinite;
+}
+
+@keyframes scrollCueBounce {
+  0%, 100% {
+    transform: translate(-50%, 0);
+  }
+  50% {
+    transform: translate(-50%, -6px);
+  }
 }
 
 .hero-headline {


### PR DESCRIPTION
## Summary
- Animate hero section with Framer Motion and show a bottom scroll cue
- Style scroll cue with bounce animation and position hero section relative

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dc82d5308329b035d5b4db94b3ff