### PR TITLE
Simplify home cards and remove constellation styles

### DIFF
--- a/src/components/ConstellationSection.jsx
+++ b/src/components/ConstellationSection.jsx
@@ -1,29 +1,25 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import InteractiveBackground from './InteractiveBackground';
 import '../styles/components.css';
 
 const ConstellationSection = ({ icon, title, description, buttonText, onClick }) => {
   return (
-    <section className="constellation-section">
-      <InteractiveBackground />
-      <motion.div
-        className="constellation-content"
-        initial={{ opacity: 0, y: 40 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
-      >
-        {icon && <div className="constellation-icon">{icon}</div>}
-        {title && <h2>{title}</h2>}
-        {description && <p>{description}</p>}
-        {buttonText && (
-          <button className="btn-primary" onClick={onClick}>
-            {buttonText}
-          </button>
-        )}
-      </motion.div>
-    </section>
+    <motion.div
+      className="home-card"
+      initial={{ opacity: 0, y: 40 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      viewport={{ once: true }}
+    >
+      {icon && <div className="home-card-icon">{icon}</div>}
+      {title && <h2>{title}</h2>}
+      {description && <p>{description}</p>}
+      {buttonText && (
+        <button className="btn-primary" onClick={onClick}>
+          {buttonText}
+        </button>
+      )}
+    </motion.div>
   );
 };
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -98,7 +98,7 @@ const Home = () => {
           </motion.section>
         </div>
         
-        <div className="constellation-wrapper">
+        <div className="home-cards-container">
           {homePageCards.map((card, idx) => (
             <ConstellationSection
               key={idx}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,23 +1,14 @@
-.constellation-section {
-  min-height: 100vh;
-  position: relative;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.constellation-section .interactive-background {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-}
-
-.constellation-content {
-  position: relative;
-  z-index: 1;
+.home-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 2rem;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home-card-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2660,16 +2660,12 @@ textarea.input-field { resize: vertical; }
 /* This is the key fix: make all page containers transparent */
 
 
-/* --- Homepage Constellation Sections --- */
-.constellation-wrapper {
-  height: 100vh;
-  overflow-y: auto;
-  scroll-snap-type: y mandatory;
-}
-
-.constellation-section {
-  height: 100vh;
-  scroll-snap-align: start;
+/* --- Homepage Cards --- */
+.home-cards-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  padding: 2rem;
 }
 
 /* --- 5. Footer --- */


### PR DESCRIPTION
## Summary
- replace constellation wrapper with standard home cards grid
- drop interactive background and render static card content
- remove constellation CSS and add minimal card styling

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4407199e88329913464608ef81409