### PR TITLE
Downgrade @react-three/fiber to React 18-compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hyperstrategies",
       "version": "0.1.0",
       "dependencies": {
-        "@react-three/fiber": "^8.18.0",
+        "@react-three/fiber": "^8.15.13",
         "axios": "^1.10.0",
         "cors": "^2.8.5",
         "ethers": "^6.15.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/fiber": "^8.18.0",
+    "@react-three/fiber": "^8.15.13",
     "axios": "^1.10.0",
     "cors": "^2.8.5",
     "ethers": "^6.15.0",


### PR DESCRIPTION
## Summary
- Downgrade @react-three/fiber to a React 18-compatible release
- Regenerate lockfile and run production build

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a452257f0083298d8baeec3a848201