### PR TITLE
Use RotatingText for home hero headline

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,14 +2,15 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import Layout from '../components/Layout';
 import GalaxyCanvas from '../components/GalaxyCanvas';
+import RotatingText from '../components/RotatingText';
 
 // --- THE FIX: We no longer need a separate CSS file for this page.
 // All styles are now in global.css, which is imported by src/index.js
 
 const Home = () => {
   const { t } = useTranslation();
+  const rotatingWords = t('home.rotating_words', { returnObjects: true });
 
   // We are creating a simplified version that does not use the Layout component
   // because it's a fullscreen experience. The Header and Footer are omitted on this page.
@@ -22,7 +23,7 @@ const Home = () => {
         <section className="hero-section-3d">
           <div className="hero-content">
             <h1 className="hero-headline">
-              HYPER-STRATEGIES
+              <RotatingText texts={rotatingWords} />
             </h1>
             <p className="hero-subtext">{t('home.hero.subtext', 'Automated Trading Solutions, Curated Crypto Vaults.')}</p>
             <div className="button-row">


### PR DESCRIPTION
## Summary
- Import and render RotatingText on the Home page hero headline
- Load rotating words from i18n translations

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a4684e08908329b8056392ba05d2e9