### PR TITLE
Fade home UI on scroll and toggle pointer events

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,7 @@
 // src/pages/Home.jsx
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import Layout from '../components/Layout';
 import GalaxyCanvas from '../components/GalaxyCanvas';
 
 // --- THE FIX: We no longer need a separate CSS file for this page.
@@ -10,15 +9,33 @@ import GalaxyCanvas from '../components/GalaxyCanvas';
 
 const Home = () => {
   const { t } = useTranslation();
+  const [uiOpacity, setUiOpacity] = useState(1);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const fadeDistance = window.innerHeight * 0.4;
+      const newOpacity = 1 - window.scrollY / fadeDistance;
+      setUiOpacity(newOpacity < 0 ? 0 : newOpacity > 1 ? 1 : newOpacity);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   // We are creating a simplified version that does not use the Layout component
   // because it's a fullscreen experience. The Header and Footer are omitted on this page.
-  
+
+  const pointerClass = uiOpacity === 0 ? ' pointer-none' : '';
+
   return (
     <div className="home-3d-wrapper">
       <GalaxyCanvas />
 
-      <div className="home-3d-ui-container">
+      <div
+        className={`home-3d-ui-container${pointerClass}`}
+        style={{ opacity: uiOpacity }}
+      >
         <section className="hero-section-3d">
           <div className="hero-content">
             <h1 className="hero-headline">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3422,14 +3422,12 @@ input:checked + .slider:before {
   left: 0;
   width: 100%;
   height: 100%;
-  pointer-events: none; /* Allows clicks to go through to the canvas, except for buttons */
+  pointer-events: auto;
+  transition: opacity 0.5s ease;
 }
 
-/* Make sure buttons and links inside the UI are clickable */
-.home-3d-ui-container .btn-primary,
-.home-3d-ui-container .btn-outline,
-.home-3d-ui-container a {
-  pointer-events: auto;
+.home-3d-ui-container.pointer-none {
+  pointer-events: none;
 }
 
 .hero-section-3d .button-row {


### PR DESCRIPTION
## Summary
- Fade out home overlay as the user scrolls and compute opacity based on scroll position.
- Disable pointer events on the UI overlay when transparent so the 3D cards remain interactive.

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a46855c7588329a13dfab53c422a40