### PR TITLE
chore: remove unused scroll state

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -25,8 +25,6 @@ const Home = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const [scrollOffset, setScrollOffset] = useState(0);
-
   const rotatingWords = t('home.rotating_words', { returnObjects: true });
 
 
@@ -40,7 +38,7 @@ const Home = () => {
 
   return (
     <div className="home-3d-wrapper">
-      <GalaxyCanvas onScroll={setScrollOffset} />
+      <GalaxyCanvas />
 
       <div
 


### PR DESCRIPTION
## Summary
- remove unused `scrollOffset` state and `onScroll` prop from Home page since UI does not need real-time scroll data from `GalaxyCanvas`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48936c3888329bdddbd2297e51faf