### PR TITLE
feat: add button support to floating cards

### DIFF
--- a/src/components/FloatingCard.jsx
+++ b/src/components/FloatingCard.jsx
@@ -3,7 +3,20 @@ import React from 'react';
 import { Text, Plane } from '@react-three/drei';
 import { motion } from 'framer-motion';
 
-const FloatingCard = ({ title, description, position, delay = 0 }) => {
+const FloatingCard = ({
+  title,
+  description,
+  buttonLabel,
+  link,
+  position,
+  delay = 0,
+}) => {
+  const handleClick = () => {
+    if (link) {
+      window.open(link, '_blank');
+    }
+  };
+
   return (
     <motion.group
       position={position}
@@ -11,8 +24,12 @@ const FloatingCard = ({ title, description, position, delay = 0 }) => {
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.6, delay }}
     >
-      <Plane args={[4, 2]} /* width, height */ >
-        <meshStandardMaterial color="#101827" metalness={0.1} roughness={0.2} />
+      <Plane args={[4, 2]} /* width, height */>
+        <meshStandardMaterial
+          color="#101827"
+          metalness={0.1}
+          roughness={0.2}
+        />
       </Plane>
       <Text
         position={[0, 0.5, 0.1]}
@@ -35,6 +52,18 @@ const FloatingCard = ({ title, description, position, delay = 0 }) => {
       >
         {description}
       </Text>
+      {buttonLabel && (
+        <Text
+          position={[0, -0.6, 0.1]}
+          fontSize={0.15}
+          color="#3fbaf3"
+          anchorX="center"
+          anchorY="middle"
+          onClick={handleClick}
+        >
+          {buttonLabel}
+        </Text>
+      )}
     </motion.group>
   );
 };

--- a/src/components/GalaxyCanvas.jsx
+++ b/src/components/GalaxyCanvas.jsx
@@ -15,29 +15,37 @@ const GalaxyCanvas = () => {
   const cards = ['managed', 'airdrop', 'self'];
 
   return (
-    <Canvas 
-      camera={{ position: [0, 0, 5], fov: 75 }}
-      gl={{ outputColorSpace: THREE.SRGBColorSpace }}
-    >
-      <ambientLight intensity={0.5} />
-      <pointLight position={[10, 10, 10]} intensity={1} />
+    <div className="galaxy-canvas-wrapper">
+      <h2 className="cards-title">{t('home.cards.title')}</h2>
+      <Canvas
+        camera={{ position: [0, 0, 5], fov: 75 }}
+        gl={{ outputColorSpace: THREE.SRGBColorSpace }}
+      >
+        <ambientLight intensity={0.5} />
+        <pointLight position={[10, 10, 10]} intensity={1} />
 
-      <Suspense fallback={null}>
-        <ScrollControls pages={cards.length} damping={0.3}>
-          <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade />
-          <ScrollManager distance={CARD_SPACING * cards.length} />
-          {cards.map((key, index) => (
-            <FloatingCard
-              key={key}
-              title={t(`home.cards.${key}.title`)}
-              description={t(`home.cards.${key}.text`)}
-              position={[0, START_Y - index * CARD_SPACING, 0]}
-              delay={index * 0.2}
-            />
-          ))}
-        </ScrollControls>
-      </Suspense>
-    </Canvas>
+        <Suspense fallback={null}>
+          <ScrollControls pages={cards.length} damping={0.3}>
+            <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade />
+            <ScrollManager distance={CARD_SPACING * cards.length} />
+            {cards.map((key, index) => {
+              const link = t(`home.cards.${key}.link`, '');
+              return (
+                <FloatingCard
+                  key={key}
+                  title={t(`home.cards.${key}.title`)}
+                  description={t(`home.cards.${key}.text`)}
+                  buttonLabel={t(`home.cards.${key}.button`, '')}
+                  link={link || undefined}
+                  position={[0, START_Y - index * CARD_SPACING, 0]}
+                  delay={index * 0.2}
+                />
+              );
+            })}
+          </ScrollControls>
+        </Suspense>
+      </Canvas>
+    </div>
   );
 };
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -276,7 +276,8 @@
       "airdrop": {
         "title": "XP, Stufen & Rangliste",
         "text": "Interagiere mit der Plattform, sammle XP, steigere dein Kontolevel und wetteifere um zukünftige Token-Zuteilungen.",
-        "button": "RANGLISTE ANSEHEN"
+        "button": "RANGLISTE ANSEHEN",
+        "link": "/xpleaderboard"
       },
       "self": {
         "title": "Strategy Builder Engine",
@@ -286,12 +287,14 @@
       "managed": {
         "title": "Investiere in verwaltete Vaults",
         "text": "Zahle ein und lass unsere Systeme und Trader in kuratierten Hochleistungs-Vaults für dich arbeiten.",
-        "button": "Anmelden"
+        "button": "Anmelden",
+        "link": "/login"
       },
       "investor": {
         "title": "Hyper Strategies Info",
         "text": "Erfahre mehr über Hyper-Strategies in unserem Gitbook.",
-        "button": "Mehr erfahren"
+        "button": "Mehr erfahren",
+        "link": "https://hyper-strategies.gitbook.io/hyper-strategies-docs/"
       }
     }
   },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -281,7 +281,8 @@
       "airdrop": {
         "title": "XP, Tiers & Leaderboard",
         "text": "Engage with the platform to earn XP, climb account tiers, and compete for future token allocations.",
-        "button": "VIEW LEADERBOARD"
+        "button": "VIEW LEADERBOARD",
+        "link": "/xpleaderboard"
       },
       "self": {
         "title": "Strategy Builder Engine",
@@ -291,12 +292,14 @@
       "managed": {
         "title": "Invest in Managed Vaults",
         "text": "Deposit and let our systems and traders work for you in curated, high-performance vaults.",
-        "button": "VISIT DASHBOARD"
+        "button": "VISIT DASHBOARD",
+        "link": "/login"
       },
       "investor": {
         "title": "Hyper Strategies Info",
         "text": "Learn about Hyper-Strategies from our Gitbook.",
-        "button": "Learn More"
+        "button": "Learn More",
+        "link": "https://hyper-strategies.gitbook.io/hyper-strategies-docs/"
       }
     }
   },

--- a/src/i18n/troll.json
+++ b/src/i18n/troll.json
@@ -277,7 +277,9 @@
       "title": "Tollolol Tollolol-Tollolol",
       "airdrop": {
         "title": "Troll Tollolol",
-        "text": "Troll Troll Troll Tollolol Tollolol"
+        "text": "Troll Troll Troll Tollolol Tollolol",
+        "button": "Tollolol Troll",
+        "link": "/xpleaderboard"
       },
       "self": {
         "title": "Tollolol Tollolol Tollolol",
@@ -286,12 +288,15 @@
       },
       "managed": {
         "title": "Tollolol Troll Tollolol Tollolol",
-        "text": "Tollolol Troll Troll Troll Tollolol Tollolol Troll Troll"
+        "text": "Tollolol Troll Troll Troll Tollolol Tollolol Troll Troll",
+        "button": "Tollolol Troll",
+        "link": "/login"
       },
       "investor": {
         "title": "Tollolol Tollolol Troll",
         "text": "Tollolol Tollolol Tollolol-Tollolol Troll Troll Tollolol.",
-        "button": "Tollolol Troll"
+        "button": "Tollolol Troll",
+        "link": "https://hyper-strategies.gitbook.io/hyper-strategies-docs/"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add optional button and link to floating cards
- pass button data from i18n and show cards title heading
- include new link entries in translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4893d3a648329843e05216182320a