### PR TITLE
fix: make home page wrapper scrollable

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import RotatingText from '../components/RotatingText';
 const Home = () => {
   const { t } = useTranslation();
   const [uiOpacity, setUiOpacity] = useState(1);
+  const cardKeys = ['managed', 'airdrop', 'self', 'investor'];
 
   const handleScroll = (scrollOffset) => {
     const fadeStart = 0.02;
@@ -22,33 +23,44 @@ const Home = () => {
   const rotatingWords = t('home.rotating_words', { returnObjects: true }) || [];
 
   return (
-    <div className="home-3d-wrapper">
-      <GalaxyCanvas onScrollUpdate={handleScroll} />
+    <div>
+      <div className="home-3d-wrapper">
+        <GalaxyCanvas onScrollUpdate={handleScroll} />
 
-      <div
-        className="home-3d-ui-container"
-        style={{ opacity: uiOpacity, pointerEvents: uiOpacity > 0.1 ? 'auto' : 'none' }}
-      >
-        <section className="hero-section-3d">
-          <div className="hero-content">
-            <h1 className="hero-headline">
-              <RotatingText texts={rotatingWords} suffix="-STRATEGIES" />
-            </h1>
-            <p className="hero-subtext">{t('home.hero.subtext', 'Automated Trading Solutions, Curated Crypto Vaults.')}</p>
-            <div className="button-row" style={{ justifyContent: 'center' }}>
-              <Link to="/register" className="btn-primary btn-large">{t('home.hero.register_now', 'Register Now')}</Link>
-              <Link to="/login" className="btn-outline btn-large">{t('home.hero.sign_in', 'Sign In')}</Link>
+        <div
+          className="home-3d-ui-container"
+          style={{ opacity: uiOpacity, pointerEvents: uiOpacity > 0.1 ? 'auto' : 'none' }}
+        >
+          <section className="hero-section-3d">
+            <div className="hero-content">
+              <h1 className="hero-headline">
+                <RotatingText texts={rotatingWords} suffix="-STRATEGIES" />
+              </h1>
+              <p className="hero-subtext">{t('home.hero.subtext', 'Automated Trading Solutions, Curated Crypto Vaults.')}</p>
+              <div className="button-row" style={{ justifyContent: 'center' }}>
+                <Link to="/register" className="btn-primary btn-large">{t('home.hero.register_now', 'Register Now')}</Link>
+                <Link to="/login" className="btn-outline btn-large">{t('home.hero.sign_in', 'Sign In')}</Link>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        {uiOpacity > 0 && (
-          <div className="scroll-cue-3d">
-            <span>Scroll Down to Explore</span>
-            <div className="scroll-arrow">↓</div>
-          </div>
-        )}
+          {uiOpacity > 0 && (
+            <div className="scroll-cue-3d">
+              <span>Scroll Down to Explore</span>
+              <div className="scroll-arrow">↓</div>
+            </div>
+          )}
+        </div>
       </div>
+
+      <section className="home-card-listings">
+        <h2>{t('home.cards.title')}</h2>
+        <ul>
+          {cardKeys.map((key) => (
+            <li key={key}>{t(`home.cards.${key}.title`)}</li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3353,11 +3353,12 @@ html, body {
 
 /* This is the main container that holds the 3D canvas */
 .home-3d-wrapper {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
+  overflow-y: auto;
   background-color: var(--color-background);
 }
 
@@ -3375,6 +3376,21 @@ html, body {
 /* We re-enable pointer events ONLY for the direct children of the UI container */
 .home-3d-ui-container > * {
   pointer-events: auto;
+}
+
+/* Section for listing cards or other content below the hero */
+.home-card-listings {
+  padding: 2rem 1rem;
+}
+
+.home-card-listings ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+
+.home-card-listings li + li {
+  margin-top: 0.5rem;
 }
 
 /* This styles the main 'hero' section with the title and buttons */


### PR DESCRIPTION
## Summary
- allow home wrapper to scroll vertically instead of being fixed
- render card section after hero to ensure sections stack

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad0cfff4832980fe6282ef275403