### PR TITLE
Ensure GalaxyCanvas spans full screen

### DIFF
--- a/src/components/GalaxyCanvas.jsx
+++ b/src/components/GalaxyCanvas.jsx
@@ -14,7 +14,8 @@ const GalaxyCanvas = ({ onScrollUpdate }) => {
   const cards = ['managed', 'airdrop', 'self'];
 
   return (
-    <Canvas 
+    <Canvas
+      style={{ width: '100%', height: '100vh' }}
       camera={{ position: [0, 0, 5], fov: 75 }}
       gl={{ outputColorSpace: THREE.SRGBColorSpace }}
     >


### PR DESCRIPTION
## Summary
- Make GalaxyCanvas Canvas element fill the viewport

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4c6c677c88329a526518c1d1021cc