### PR TITLE
Use native window scroll for 3D scene

### DIFF
--- a/src/components/GalaxyCanvas.jsx
+++ b/src/components/GalaxyCanvas.jsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { ScrollControls, Stars } from '@react-three/drei';
+import { Stars } from '@react-three/drei';
 import ScrollManager from './ScrollManager';
 import FloatingCard from './FloatingCard';
 import { useTranslation } from 'react-i18next';
@@ -22,23 +22,21 @@ const GalaxyCanvas = ({ onScrollUpdate }) => {
       <ambientLight intensity={0.8} />
       <pointLight position={[10, 10, 10]} intensity={1.5} />
       <Suspense fallback={null}>
-        <ScrollControls pages={cards.length} damping={0.25}>
-          <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
-          <ScrollManager 
-            distance={cards.length * CARD_SPACING} 
-            onScrollUpdate={onScrollUpdate} 
+        <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
+        <ScrollManager
+          distance={cards.length * CARD_SPACING}
+          onScrollUpdate={onScrollUpdate}
+        />
+        {/* The cards are now positioned along the Z-axis for the fly-through effect */}
+        {cards.map((key, index) => (
+          <FloatingCard
+            key={key}
+            title={t(`home.cards.${key}.title`)}
+            description={t(`home.cards.${key}.text`)}
+            position={[0, 0, -index * CARD_SPACING]}
+            delay={index * 0.2}
           />
-          {/* The cards are now positioned along the Z-axis for the fly-through effect */}
-          {cards.map((key, index) => (
-            <FloatingCard
-              key={key}
-              title={t(`home.cards.${key}.title`)}
-              description={t(`home.cards.${key}.text`)}
-              position={[0, 0, -index * CARD_SPACING]}
-              delay={index * 0.2}
-            />
-          ))}
-        </ScrollControls>
+        ))}
       </Suspense>
     </Canvas>
   );

--- a/src/components/ScrollManager.jsx
+++ b/src/components/ScrollManager.jsx
@@ -1,17 +1,28 @@
-import { useScroll } from '@react-three/drei';
+import { useEffect, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 
 const ScrollManager = ({ distance, onScrollUpdate }) => {
-  const scroll = useScroll();
+  const scrollRef = useRef(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollY = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const offset = docHeight > 0 ? scrollY / docHeight : 0;
+      scrollRef.current = offset;
+      if (onScrollUpdate) {
+        onScrollUpdate(offset);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [onScrollUpdate]);
 
   useFrame((state) => {
-    const scrollOffset = scroll.offset;
-    // Animate the camera's Z position for a "flying through space" effect
+    const scrollOffset = scrollRef.current;
     state.camera.position.z = 5 - scrollOffset * distance;
-    
-    if (onScrollUpdate) {
-      onScrollUpdate(scrollOffset);
-    }
   });
 
   return null;


### PR DESCRIPTION
## Summary
- Remove Drei's ScrollControls and render ScrollManager directly inside the canvas
- Listen to `window.scrollY` in ScrollManager to move the camera and report scroll progress

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc2657b483298e476078da3cbd3c