### PR TITLE
Add default rotating words fallback and warning for missing translation

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,7 +20,12 @@ const Home = () => {
     }
   };
 
-  const rotatingWords = t('home.rotating_words', { returnObjects: true }) || [];
+  const defaultRotatingWords = ['AUTOMATED', 'HEDGEFUND', 'EXPERIMENTAL', 'HYPER'];
+  let rotatingWords = t('home.rotating_words', { returnObjects: true });
+  if (!Array.isArray(rotatingWords)) {
+    console.warn("Missing or invalid translation for 'home.rotating_words'. Falling back to defaults.");
+    rotatingWords = defaultRotatingWords;
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- ensure rotating words is an array, falling back to default terms when missing
- log a warning when the 'home.rotating_words' translation key is absent

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a4d42189888329a893fcc285265ed4