### PR TITLE
feat: restore galaxy home experience

### DIFF
--- a/src/components/FloatingCard.jsx
+++ b/src/components/FloatingCard.jsx
@@ -1,39 +1,65 @@
-import React from 'react';
-import { Text } from '@react-three/drei';
-import { motion } from 'framer-motion';
+import React, { useMemo, useRef } from 'react';
+import { Float, Text } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { MathUtils } from 'three';
 
 const FloatingCard = ({ title, description, position, delay = 0 }) => {
+  const groupRef = useRef();
+  const baseScale = 0.85;
+  const speed = useMemo(() => 0.6 + delay * 0.3, [delay]);
+  const delaySeconds = delay * 0.4;
+  const animationDuration = 0.6;
+  const startTimeRef = useRef(null);
+
+  useFrame(({ clock }) => {
+    if (!groupRef.current) {
+      return;
+    }
+
+    if (startTimeRef.current === null) {
+      startTimeRef.current = clock.elapsedTime;
+    }
+
+    const elapsed = clock.elapsedTime - startTimeRef.current;
+    const progress = Math.max(elapsed - delaySeconds, 0);
+    const normalized = Math.min(progress / animationDuration, 1);
+    const eased = MathUtils.smoothstep(normalized, 0, 1);
+    const nextScale = MathUtils.lerp(baseScale, 1, eased);
+    groupRef.current.scale.setScalar(nextScale);
+  });
+
   return (
-    <motion.group
+    <Float
       position={position}
-      initial={{ opacity: 0, scale: 0.8, y: position[1] + 2 }}
-      animate={{ opacity: 1, scale: 1, y: position[1] }}
-      transition={{ duration: 0.8, delay, ease: 'easeOut' }}
+      speed={speed}
+      rotationIntensity={0.18}
+      floatIntensity={0.45}
+      floatingRange={[-0.4, 0.4]}
     >
-      <Text
-        position={[0, 0.5, 0.1]}
-        fontSize={0.3}
-        color="#3fbaf3"
-        anchorX="center"
-        anchorY="middle"
-        // --- THE FIX: Removed the 'font' prop to use the default ---
-      >
-        {title}
-      </Text>
-      <Text
-        position={[0, -0.1, 0.1]}
-        fontSize={0.15}
-        color="#a0aec0"
-        maxWidth={3.5}
-        textAlign="center"
-        anchorX="center"
-        anchorY="middle"
-        lineHeight={1.5}
-        // --- THE FIX: Removed the 'font' prop to use the default ---
-      >
-        {description}
-      </Text>
-    </motion.group>
+      <group ref={groupRef} scale={baseScale}>
+        <Text
+          position={[0, 0.5, 0.1]}
+          fontSize={0.3}
+          color="#3fbaf3"
+          anchorX="center"
+          anchorY="middle"
+        >
+          {title}
+        </Text>
+        <Text
+          position={[0, -0.1, 0.1]}
+          fontSize={0.15}
+          color="#a0aec0"
+          maxWidth={3.5}
+          textAlign="center"
+          anchorX="center"
+          anchorY="middle"
+          lineHeight={1.5}
+        >
+          {description}
+        </Text>
+      </group>
+    </Float>
   );
 };
 

--- a/src/components/GalaxyCanvas.jsx
+++ b/src/components/GalaxyCanvas.jsx
@@ -1,59 +1,43 @@
 // src/components/GalaxyCanvas.jsx
 import React, { Suspense } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
-import { ScrollControls, Stars, useScroll } from '@react-three/drei';
+import { Canvas } from '@react-three/fiber';
+import { Stars } from '@react-three/drei';
 import FloatingCard from './FloatingCard';
-import { useTranslation } from 'react-i18next';
+import ScrollManager from './ScrollManager';
 
 const CARD_SPACING = 7;
 
-// This new component is our "scene" and contains the animation logic.
-const Scene = ({ onScrollUpdate }) => {
-  const scroll = useScroll(); // This hook gives us the scroll progress
-  const { t } = useTranslation();
-  const cards = ['managed', 'airdrop', 'self'];
+const Scene = ({ cards }) => (
+  <>
+    <color attach="background" args={['#020617']} />
+    <ambientLight intensity={0.6} />
+    <Stars radius={80} depth={40} count={4000} factor={4} saturation={0} fade speed={0.6} />
+    {cards.map((card, index) => (
+      <FloatingCard
+        key={card.key}
+        title={card.title}
+        description={card.description}
+        position={[0, 0, -index * CARD_SPACING]}
+        delay={index * 0.2}
+      />
+    ))}
+  </>
+);
 
-  useFrame((state) => {
-    // This function runs on every frame
-    const scrollOffset = scroll.offset;
-    // Animate the camera's Z position
-    state.camera.position.z = 5 - scrollOffset * (cards.length * CARD_SPACING);
-    // Pass the scroll offset up to the Home component
-    if (onScrollUpdate) {
-      onScrollUpdate(scrollOffset);
-    }
-  });
-
-  return (
-    <>
-      <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
-      {cards.map((key, index) => (
-        <FloatingCard
-          key={key}
-          title={t(`home.cards.${key}.title`)}
-          description={t(`home.cards.${key}.text`)}
-          position={[0, 0, -index * CARD_SPACING]}
-        />
-      ))}
-    </>
-  );
-};
-
-const GalaxyCanvas = ({ onScrollUpdate }) => {
-  const { t } = useTranslation();
-  const cards = ['managed', 'airdrop', 'self'];
+const GalaxyCanvas = ({ cards = [], onScrollUpdate }) => {
+  const safeCards = cards.filter(Boolean);
+  const travelDistance = safeCards.length * CARD_SPACING;
 
   return (
-    // --- THE FIX: Add the new CSS class ---
     <div className="home-3d-canvas">
-      <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
+      <Canvas camera={{ position: [0, 0, 5], fov: 60 }} dpr={[1, 1.5]}>
         <Suspense fallback={null}>
-          <ScrollControls pages={cards.length} damping={0.25}>
-            <Scene onScrollUpdate={onScrollUpdate} />
-          </ScrollControls>
+          <ScrollManager distance={travelDistance} onScrollUpdate={onScrollUpdate} />
+          <Scene cards={safeCards} />
         </Suspense>
       </Canvas>
     </div>
   );
 };
+
 export default GalaxyCanvas;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -5,21 +5,24 @@ import InteractiveBackground from './InteractiveBackground';
 import PlasmaEffect from './PlasmaEffect';
 import { useAnimationSettings } from '../context/AnimationSettingsContext';
 
-const Layout = ({ children, showInteractiveBackground = true }) => {
+const Layout = ({ children, showInteractiveBackground = true, showPlasmaBackground = true, showFooter = true }) => {
   const { settings } = useAnimationSettings();
   const {
     general: { showPlasma, showNetwork },
   } = settings;
 
+  const shouldShowPlasma = showPlasmaBackground && showPlasma;
+  const shouldShowNetwork = showInteractiveBackground && showNetwork;
+
   return (
     <div className="layout-wrapper" style={{ backgroundColor: 'var(--color-background)' }}>
-      {showPlasma && <PlasmaEffect />}
-      {showInteractiveBackground && showNetwork && <InteractiveBackground />}
+      {shouldShowPlasma && <PlasmaEffect />}
+      {shouldShowNetwork && <InteractiveBackground />}
       <Header />
       <main className="main-content">
         {children}
       </main>
-      <Footer />
+      {showFooter && <Footer />}
     </div>
   );
 };

--- a/src/components/ScrollManager.jsx
+++ b/src/components/ScrollManager.jsx
@@ -1,12 +1,16 @@
 import { useEffect, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 
-const ScrollManager = ({ distance, onScrollUpdate }) => {
+const ScrollManager = ({ distance = 0, onScrollUpdate, scrollContainerId = 'home-3d-wrapper' }) => {
   const scrollRef = useRef(0);
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return () => {};
+    }
+
     const handleScroll = () => {
-      const wrapper = document.querySelector('.home-3d-wrapper');
+      const wrapper = document.getElementById(scrollContainerId);
       const scrollY = window.scrollY;
       const wrapperHeight = wrapper ? wrapper.offsetHeight - window.innerHeight : 0;
       const offset = wrapperHeight > 0 ? Math.min(scrollY / wrapperHeight, 1) : 0;
@@ -17,13 +21,18 @@ const ScrollManager = ({ distance, onScrollUpdate }) => {
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleScroll);
     handleScroll();
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [onScrollUpdate]);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
+    };
+  }, [onScrollUpdate, scrollContainerId]);
 
   useFrame((state) => {
     const scrollOffset = scrollRef.current;
-    state.camera.position.z = 5 - scrollOffset * distance;
+    const travelDistance = Math.max(distance, 0);
+    state.camera.position.z = 5 - scrollOffset * travelDistance;
   });
 
   return null;

--- a/src/hooks/usePrefersReducedMotion.js
+++ b/src/hooks/usePrefersReducedMotion.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+const getInitialValue = () => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(QUERY).matches;
+};
+
+const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(getInitialValue);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return () => {};
+    }
+
+    const mediaQueryList = window.matchMedia(QUERY);
+
+    const handleChange = (event) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if (typeof mediaQueryList.addEventListener === 'function') {
+      mediaQueryList.addEventListener('change', handleChange);
+      return () => mediaQueryList.removeEventListener('change', handleChange);
+    }
+
+    mediaQueryList.addListener(handleChange);
+    return () => mediaQueryList.removeListener(handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+export default usePrefersReducedMotion;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,71 +1,172 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import Layout from '../components/Layout';
 import RotatingText from '../components/RotatingText';
+import GalaxyCanvas from '../components/GalaxyCanvas';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
+import { useAnimationSettings } from '../context/AnimationSettingsContext';
 
-// Card Component - moved directly into Home.jsx for simplicity
-// REMOVED link and linkText props as the entire card is now the link.
-const Card = ({ title, text }) => (
-  <div className="home-card">
+const floatingCardKeys = ['managed', 'airdrop', 'self'];
+const gridCardKeys = ['managed', 'airdrop', 'self', 'investor'];
+
+const cardFallbacks = {
+  managed: {
+    title: 'Managed Vaults',
+    text: 'Access our flagship strategies with active, discretionary management.',
+    link: '/login',
+  },
+  airdrop: {
+    title: 'XP, Tiers & Leaderboard',
+    text: 'Engage with the platform to earn XP, climb account tiers, and compete for future token allocations.',
+    link: '/xpleaderboard',
+  },
+  self: {
+    title: 'Strategy Builder Engine',
+    text: 'Coming Soon: A powerful engine to build, backtest, and deploy your own automated trading strategies.',
+    link: '',
+  },
+  investor: {
+    title: 'Hyper Strategies Info',
+    text: 'Learn about Hyper-Strategies from our Gitbook.',
+    link: 'https://hyper-strategies.gitbook.io/hyper-strategies-docs/',
+  },
+};
+
+const Card = ({ title, text, isHighlighted }) => (
+  <div className={`home-card${isHighlighted ? ' home-card--active' : ''}`}>
     <h3>{title}</h3>
     <p>{text}</p>
   </div>
 );
 
+const isExternalLink = (link) => /^https?:\/\//i.test(link);
+
 const Home = () => {
   const { t } = useTranslation();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const { settings } = useAnimationSettings();
+  const { general: { showNetwork } = { showNetwork: true } } = settings || {};
 
   const rotatingWords = t('home.rotating_words', { returnObjects: true }) || [];
 
+  const floatingCards = useMemo(
+    () => floatingCardKeys.map((key) => {
+      const fallback = cardFallbacks[key] || { title: key, text: '' };
+      return {
+        key,
+        title: t(`home.cards.${key}.title`, { defaultValue: fallback.title }),
+        description: t(`home.cards.${key}.text`, { defaultValue: fallback.text }),
+      };
+    }),
+    [t],
+  );
+
+  const [activeCardIndex, setActiveCardIndex] = useState(0);
+
+  useEffect(() => {
+    if (!floatingCards.length) {
+      setActiveCardIndex(0);
+      return;
+    }
+
+    if (activeCardIndex > floatingCards.length - 1) {
+      setActiveCardIndex(floatingCards.length - 1);
+    }
+  }, [activeCardIndex, floatingCards.length]);
+
+  const handleScrollUpdate = useCallback((value) => {
+    if (!floatingCards.length) {
+      return;
+    }
+
+    const clamped = Math.min(Math.max(value, 0), 1);
+    const nextIndex = Math.min(floatingCards.length - 1, Math.round(clamped * (floatingCards.length - 1)));
+    setActiveCardIndex((prev) => (prev === nextIndex ? prev : nextIndex));
+  }, [floatingCards.length]);
+
+  const activeCardKey = floatingCards[activeCardIndex]?.key;
+
+  const gridCards = useMemo(
+    () => gridCardKeys.map((key) => {
+      const fallback = cardFallbacks[key] || { title: key, text: '', link: '' };
+      const title = t(`home.cards.${key}.title`, { defaultValue: fallback.title });
+      const description = t(`home.cards.${key}.text`, { defaultValue: fallback.text });
+      const link = t(`home.cards.${key}.link`, { defaultValue: fallback.link || '' });
+      return {
+        key,
+        title,
+        description,
+        link: link && link !== `home.cards.${key}.link` ? link : '',
+      };
+    }),
+    [t],
+  );
+
+  const enableGalaxy = showNetwork && !prefersReducedMotion && floatingCards.length > 0;
+
+  const homeContent = (
+    <div className="home-container">
+      <section className="hero-section">
+        <h1 className="hero-headline">
+          <RotatingText texts={rotatingWords} suffix="-STRATEGIES" />
+        </h1>
+        <p className="hero-subtext">{t('home.hero.subtext', 'Automated Trading Solutions, Curated Crypto Vaults.')}</p>
+        <div className="button-row">
+          <Link to="/register" className="btn-primary btn-large">{t('home.hero.register_now', 'Register Now')}</Link>
+          <Link to="/login" className="btn-outline btn-large">{t('home.hero.sign_in', 'Sign In')}</Link>
+        </div>
+      </section>
+
+      <section className="card-section">
+        {gridCards.map((card) => {
+          const isHighlighted = enableGalaxy && card.key === activeCardKey;
+          const cardElement = <Card title={card.title} text={card.description} isHighlighted={isHighlighted} />;
+
+          if (!card.link) {
+            return (
+              <div key={card.key} className="card-link-wrapper">
+                {cardElement}
+              </div>
+            );
+          }
+
+          if (isExternalLink(card.link)) {
+            return (
+              <a
+                key={card.key}
+                href={card.link}
+                className="card-link-wrapper"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {cardElement}
+              </a>
+            );
+          }
+
+          return (
+            <Link key={card.key} to={card.link} className="card-link-wrapper">
+              {cardElement}
+            </Link>
+          );
+        })}
+      </section>
+    </div>
+  );
+
   return (
-    <Layout>
-      <div className="home-container">
-        {/* Hero Section */}
-        <section className="hero-section">
-          <h1 className="hero-headline">
-            <RotatingText texts={rotatingWords} suffix="-STRATEGIES" />
-          </h1>
-          <p className="hero-subtext">{t('home.hero.subtext', 'Automated Trading Solutions, Curated Crypto Vaults.')}</p>
-          <div className="button-row">
-            <Link to="/register" className="btn-primary btn-large">{t('home.hero.register_now', 'Register Now')}</Link>
-            <Link to="/login" className="btn-outline btn-large">{t('home.hero.sign_in', 'Sign In')}</Link>
+    <Layout showInteractiveBackground={!enableGalaxy} showPlasmaBackground={!enableGalaxy}>
+      {enableGalaxy ? (
+        <div id="home-3d-wrapper" className="home-3d-wrapper">
+          <GalaxyCanvas cards={floatingCards} onScrollUpdate={handleScrollUpdate} />
+          <div className="home-3d-ui-container">
+            {homeContent}
           </div>
-        </section>
-
-        {/* --- THIS IS THE CORRECTED CARDS SECTION --- */}
-        <section className="card-section">
-          {/* Card 1: Invest in Vaults (Links to Dashboard) */}
-          <Link to="/dashboard" className="card-link-wrapper">
-            <Card
-              title={t('home.cards.managed.title', 'Managed Vaults')}
-              text={t('home.cards.managed.text', 'Access our flagship strategies with active, discretionary management.')}
-            />
-          </Link>
-
-          {/* Card 2: Automated Strategies (No Link, so no wrapper) */}
-          <Card
-            title={t('home.cards.automated.title', 'Automated Strategies')}
-            text={t('home.cards.automated.text', 'Explore fully-automated, quantitative strategies trading 24/7.')}
-          />
-
-          {/* Card 3: Syndicates (Links to Profile) */}
-          <Link to="/profile" className="card-link-wrapper">
-            <Card
-              title={t('home.cards.syndicate.title', 'Community Syndicates')}
-              text={t('home.cards.syndicate.text', 'Join with your community to unlock shared benefits and revenue streams.')}
-            />
-          </Link>
-          
-          {/* Card 4: XP System (Links to Rewards) */}
-          <Link to="/rewards" className="card-link-wrapper">
-            <Card
-              title={t('home.cards.referral.title', 'Referral & XP System')}
-              text={t('home.cards.referral.text', 'Earn XP, climb tiers, and unlock rewards by inviting others to the platform.')}
-            />
-          </Link>
-        </section>
-      </div>
+        </div>
+      ) : (
+        homeContent
+      )}
     </Layout>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3054,40 +3054,27 @@ input:checked + .slider:before {
 
 /* This is the main container for the entire page */
 .home-3d-wrapper {
-  position: fixed; /* Fix the entire component to the viewport */
-  top: 0;
-  left: 0;
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--color-background);
+  padding-bottom: 40vh;
+}
+
+.home-3d-canvas {
+  position: fixed;
+  inset: 0;
   width: 100vw;
   height: 100vh;
-  background-color: var(--color-background);
-}
-
-/* The Canvas component MUST have a lower z-index to sit behind the UI */
-/* This is the key to fixing the overlapping text. */
-.home-3d-canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1; /* Layer 1 (Bottom) */
-}
-
-/* The UI container MUST have a higher z-index to sit on top */
-.home-3d-ui-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 2; /* Layer 2 (Top) */
-  /* This is crucial: it allows the mouse scroll to "pass through" to the canvas below */
+  z-index: 1;
   pointer-events: none;
-  /* This ensures its children can still be scrolled if the content overflows */
-  overflow: auto;
 }
 
-/* We re-enable pointer events ONLY for the direct children of the UI container */
+.home-3d-ui-container {
+  position: relative;
+  z-index: 2;
+}
+
 .home-3d-ui-container > * {
   pointer-events: auto;
 }
@@ -3200,10 +3187,16 @@ a.card-link-wrapper {
   transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
+.home-card--active {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 35px rgba(63, 186, 243, 0.35);
+  transform: translateY(-8px);
+}
+
 .home-card:hover {
   transform: translateY(-5px);
   border-color: var(--color-primary);
-  box-shadow: 0 0 25px rgba(63, 186, 243, 0.2); 
+  box-shadow: 0 0 25px rgba(63, 186, 243, 0.2);
 }
 
 .home-card h3 {


### PR DESCRIPTION
## Summary
- restore the galaxy hero by rendering `GalaxyCanvas` behind the home content and highlighting the matching card as you scroll
- respect animation preferences and environment toggles by wiring a new `usePrefersReducedMotion` hook together with the animation settings context
- replace the `FloatingCard` motion implementation with a Drei-based float/scale animation and harden the scroll manager/layout plumbing for SSR and resize events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce12fd47548329a1d226f6aa3b6af0